### PR TITLE
Update gravatar presence selector

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -22,7 +22,7 @@
     {
       "click": {
         "optIn": ".a8c-cookie-banner-accept-all-button",
-        "presence": "div.a8c-cookie-banner"
+        "presence": "form.a8c-cookie-banner"
       },
       "domain": "gravatar.com",
       "cookies": {},


### PR DESCRIPTION
Turns out the parent element has been changed to a form. I've retained the element dot selector format, though I suppose just using the classname (just `.a8c-cookie-banner`) could work as well.

Fixes #19.